### PR TITLE
Return credit card type

### DIFF
--- a/spec/Inviqa/Worldpay/Api/Response/AuthorisedResponseSpec.php
+++ b/spec/Inviqa/Worldpay/Api/Response/AuthorisedResponseSpec.php
@@ -20,7 +20,7 @@ class AuthorisedResponseSpec extends ObjectBehavior
   <reply>
     <orderStatus orderCode="ExampleOrder1">
       <payment>
-        <paymentMethod>creditcard</paymentMethod>
+        <paymentMethod>VISA-SSL</paymentMethod>
         <amount value="5000" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
         <lastEvent>AUTHORISED</lastEvent>
         <AuthorisationId id="666"/> 
@@ -86,7 +86,7 @@ class AuthorisedResponseSpec extends ObjectBehavior
 
         $this->cardDetails()->shouldReturn([
             'creditCard' => [
-                'type' => 'creditcard',
+                'type' => 'VISA-SSL',
                 'cardholderName' => 'liviu',
                 'number' => '4444********1111',
             ]
@@ -102,7 +102,7 @@ class AuthorisedResponseSpec extends ObjectBehavior
 
         $this->cardDetails()->shouldReturn([
             'creditCard' => [
-                'type' => 'creditcard',
+                'type' => 'VISA-SSL',
                 'cardholderName' => 'liviu',
                 'number' => '4111********1111',
                 'expiryMonth' => '11',

--- a/src/Inviqa/Worldpay/Api/Response/AuthorisedResponse.php
+++ b/src/Inviqa/Worldpay/Api/Response/AuthorisedResponse.php
@@ -154,7 +154,7 @@ class AuthorisedResponse
         if ($this->hasNode('paymentMethodDetail')) {
             $this->cardDetails = [
                 'creditCard' => [
-                    'type' => $this->nodeAttributeValue('card', 'type'),
+                    'type' => $this->nodeValue('paymentMethod'),
                     'cardholderName' => $this->nodeValue('cardHolderName'),
                     'number' => $this->nodeAttributeValue('card', 'number'),
                     'expiryMonth' => $this->nodeAttributeValue('date', 'month'),


### PR DESCRIPTION
Currently the type attribute of the card node holds the "creditcard"
value instead of the actual card type. It's not very useful.

This change makes the real card type returned.