### PR TITLE
Feature/add payment reference field

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.2'
 
       - name: Get composer cache directory
         id: composercache

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,12 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "sabre/xml": "^2.1",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^5.0",
+        "phpspec/phpspec": "^6.3.0",
         "behat/behat": "^3.4",
         "webmozart/assert": "^1.3"
     },

--- a/features/bootstrap/NotificationContext.php
+++ b/features/bootstrap/NotificationContext.php
@@ -80,10 +80,10 @@ class NotificationContext implements Context
     }
 
     /**
-     * @Then the notification reference is
+     * @Then the notification reference is :reference
      */
-    public function theNotificationReferenceIs(PyStringNode $reference)
+    public function theNotificationReferenceIs(string $reference)
     {
-        Assert::eq($this->response->reference(), (string) $reference);
+        Assert::eq($this->response->reference(), $reference);
     }
 }

--- a/features/bootstrap/Services/FakeClient.php
+++ b/features/bootstrap/Services/FakeClient.php
@@ -46,7 +46,7 @@ class FakeClient implements Client
             );
         }
 
-        if (strstr($xml, "</refund>") !== false) {
+        if (strstr($xml, "<refund>") !== false || preg_match('/<refund reference="\d+">/', $xml) === 1) {
             return HttpResponse::fromContentAndCookie(
                 RefundFactory::cseRefundResponseXmlForOrderCode($orderCode),
                 "machine:123"

--- a/features/bootstrap/Services/FakeClient.php
+++ b/features/bootstrap/Services/FakeClient.php
@@ -39,7 +39,7 @@ class FakeClient implements Client
             return HttpResponse::fromContentAndCookie(OrderFactory::cse3DSFlexResponseXMl($orderCode));
         }
 
-        if (strstr($xml, "<capture>") !== false) {
+        if (strstr($xml, "<capture>") !== false || preg_match('/<capture reference="\d+">/', $xml) === 1) {
             return HttpResponse::fromContentAndCookie(
                 CaptureFactory::cseCaptureResponseXmlForOrderCode($orderCode),
                 "machine:123"

--- a/features/integration/api/modify.feature
+++ b/features/integration/api/modify.feature
@@ -39,3 +39,14 @@ Feature: Payment modification requests are made against the Worldpay payment gat
         Then I should receive a void response
         And the response should be successful
         And the response should reference the "32796901" order code
+
+    Scenario: Successful multi-capture request
+        When I send the following capture modification
+            | merchantCode | SESSIONECOM |
+            | orderCode    | 32796901    |
+            | currencyCode | GBP         |
+            | amount       | 15          |
+            | reference    | 1234        |
+        Then I should receive a capture response
+        And the response should be successful
+        And the response should reference the "32796901" order code

--- a/features/integration/api/modify.feature
+++ b/features/integration/api/modify.feature
@@ -50,3 +50,14 @@ Feature: Payment modification requests are made against the Worldpay payment gat
         Then I should receive a capture response
         And the response should be successful
         And the response should reference the "32796901" order code
+
+    Scenario: Successful multi-refund request
+        When I send the following refund modification
+            | merchantCode | SESSIONECOM |
+            | orderCode    | 32796901    |
+            | currencyCode | GBP         |
+            | amount       | 15          |
+            | reference    | 1234        |
+        Then I should receive a refund response
+        And the response should be successful
+        And the response should reference the "32796901" order code

--- a/features/integration/notification/payment_notification.feature
+++ b/features/integration/notification/payment_notification.feature
@@ -38,10 +38,7 @@ Feature: a payment notification request is to a notification response
         """
         Then a successful notification response should be returned
         And the notification response should reference the 123456 order code
-        And the notification reference is
-        """
-        1234
-        """
+        And the notification reference is "1234"
         And the notification response is captured
 
     Scenario: Converting a capture failed notification request
@@ -123,10 +120,7 @@ Feature: a payment notification request is to a notification response
         Then a successful notification response should be returned
         And the notification response should reference the 456789 order code
         And the notification response is refunded
-        And the notification reference is
-        """
-        1234
-        """
+        And the notification reference is "1234"
 
     Scenario: Converting a refund notification request
         When the following notification request is parsed
@@ -167,7 +161,4 @@ Feature: a payment notification request is to a notification response
         Then a successful notification response should be returned
         And the notification response should reference the 456789 order code
         And the notification response is refund failed
-        And the notification reference is
-        """
-        1234
-        """
+        And the notification reference is "1234"

--- a/features/integration/notification/payment_notification.feature
+++ b/features/integration/notification/payment_notification.feature
@@ -13,7 +13,7 @@ Feature: a payment notification request is to a notification response
                 <paymentMethod>VISA-SSL</paymentMethod>
                   <amount value="1000" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
                 <lastEvent>CAPTURED</lastEvent>
-                <reference>YourReference</reference> <!--Returned if added to capture modifications-->
+                <reference>1234</reference> <!--Returned if added to capture modifications-->
                 <balance accountType="IN_PROCESS_CAPTURED">
                   <amount value="1000" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
                 </balance>
@@ -38,6 +38,10 @@ Feature: a payment notification request is to a notification response
         """
         Then a successful notification response should be returned
         And the notification response should reference the 123456 order code
+        And the notification reference is
+        """
+        1234
+        """
         And the notification response is captured
 
     Scenario: Converting a capture failed notification request

--- a/features/integration/notification/payment_notification.feature
+++ b/features/integration/notification/payment_notification.feature
@@ -97,7 +97,7 @@ Feature: a payment notification request is to a notification response
                 <paymentMethod>VISA-SSL</paymentMethod>
                   <amount value="1000" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
                 <lastEvent>SENT_FOR_REFUND</lastEvent>
-                <reference>{"notifyClient":true,"returnNumber":"RN0000000"}</reference>
+                <reference>1234</reference>
                 <balance accountType="IN_PROCESS_CAPTURED">
                   <amount value="1000" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
                 </balance>
@@ -125,7 +125,7 @@ Feature: a payment notification request is to a notification response
         And the notification response is refunded
         And the notification reference is
         """
-        {"notifyClient":true,"returnNumber":"RN0000000"}
+        1234
         """
 
     Scenario: Converting a refund notification request
@@ -141,7 +141,7 @@ Feature: a payment notification request is to a notification response
                 <paymentMethod>VISA-SSL</paymentMethod>
                   <amount value="1000" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
                 <lastEvent>REFUND_FAILED</lastEvent>
-                <reference>{"notifyClient":true,"returnNumber":"RN0000000"}</reference>
+                <reference>1234</reference>
                 <balance accountType="IN_PROCESS_CAPTURED">
                   <amount value="1000" currencyCode="GBP" exponent="2" debitCreditIndicator="credit"/>
                 </balance>
@@ -169,5 +169,5 @@ Feature: a payment notification request is to a notification response
         And the notification response is refund failed
         And the notification reference is
         """
-        {"notifyClient":true,"returnNumber":"RN0000000"}
+        1234
         """

--- a/src/Inviqa/Worldpay/Api/Request/CaptureRequestFactory.php
+++ b/src/Inviqa/Worldpay/Api/Request/CaptureRequestFactory.php
@@ -23,6 +23,7 @@ class CaptureRequestFactory
         'exponent' => "2",
         'amount' => "",
         'debitCreditValue' => "",
+        'reference' => null,
     ];
 
     public function buildFromRequestParameters(array $parameters): PaymentService
@@ -36,8 +37,9 @@ class CaptureRequestFactory
             new Value($parameters['amount'])
         );
 
+        $reference           = empty($parameters['reference']) ? null : new Capture\Reference($parameters['reference']);
         $orderCode           = new OrderCode($parameters['orderCode']);
-        $capture             = new Capture($amount);
+        $capture             = new Capture($amount, $reference);
         $captureModification = new CaptureModification($orderCode, $capture);
 
         $paymentService = new PaymentService(

--- a/src/Inviqa/Worldpay/Api/Request/PaymentService/Modify/OrderModification/Capture/Capture.php
+++ b/src/Inviqa/Worldpay/Api/Request/PaymentService/Modify/OrderModification/Capture/Capture.php
@@ -4,21 +4,26 @@ namespace Inviqa\Worldpay\Api\Request\PaymentService\Modify\OrderModification\Ca
 
 use Inviqa\Worldpay\Api\Request\PaymentService\Modify\OrderModification;
 use Inviqa\Worldpay\Api\XmlNodeDefaults;
+use Inviqa\Worldpay\Api\Request\PaymentService\Modify\OrderModification\Capture\Capture\Reference;
 
 class Capture extends XmlNodeDefaults implements OrderModification
 {
     private $amount;
+    private $reference;
 
     public function __construct(
-        Amount $amount
+        Amount $amount,
+        ?Reference $reference = null
     ) {
         $this->amount = $amount;
+        $this->reference = $reference;
     }
 
     public function xmlChildren()
     {
         return [
-            $this->amount
+            $this->reference,
+            $this->amount,
         ];
     }
 }

--- a/src/Inviqa/Worldpay/Api/Request/PaymentService/Modify/OrderModification/Capture/Capture/Reference.php
+++ b/src/Inviqa/Worldpay/Api/Request/PaymentService/Modify/OrderModification/Capture/Capture/Reference.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Inviqa\Worldpay\Api\Request\PaymentService\Modify\OrderModification\Capture\Capture;
+
+use Inviqa\Worldpay\Api\XmlAttributeDefaults;
+
+class Reference extends XmlAttributeDefaults
+{
+}

--- a/src/Inviqa/Worldpay/Api/Request/PaymentService/Modify/OrderModification/Refund/Refund.php
+++ b/src/Inviqa/Worldpay/Api/Request/PaymentService/Modify/OrderModification/Refund/Refund.php
@@ -11,7 +11,7 @@ class Refund extends XmlNodeDefaults implements OrderModification
     private $reference;
 
     public function __construct(
-        Reference $reference,
+        ?Reference $reference = null,
         Amount $amount
     ) {
         $this->reference = $reference;

--- a/src/Inviqa/Worldpay/Api/Request/RefundRequestFactory.php
+++ b/src/Inviqa/Worldpay/Api/Request/RefundRequestFactory.php
@@ -24,7 +24,7 @@ class RefundRequestFactory
         'exponent'         => "2",
         'amount'           => "",
         'debitCreditValue' => "",
-        'reference'        => "",
+        'reference'        => null,
     ];
 
     public function buildFromRequestParameters(array $parameters): PaymentService
@@ -39,7 +39,7 @@ class RefundRequestFactory
         );
 
         $orderCode          = new OrderCode($parameters['orderCode']);
-        $reference          = new Reference($parameters['reference']);
+        $reference          = empty($parameters['reference']) ? null : new Reference($parameters['reference']);
         $refund             = new Refund($reference, $amount);
         $refundModification = new RefundModification($orderCode, $refund);
 


### PR DESCRIPTION
Add reference field to capture/refund actions
    
In a multi-capture/-refund scenario there are more than one capture request for the same orderCode. When the asynchronous order notification comes back from Worldpay the is no way to tell which capture initiated the notification.
    
This change solves that by adding a reference field to the capture request which will be sent back in the WP notification.