### PR TITLE
Add config option to remove empty Fraudsight fields

### DIFF
--- a/features/bootstrap/ApiContext.php
+++ b/features/bootstrap/ApiContext.php
@@ -378,7 +378,7 @@ class ApiContext implements Context
             $params = $this->defineShippingAddressParams($params);
         }
 
-        $authRequestFactory = new AuthorizeRequestFactoryApplePay();
+        $authRequestFactory = new AuthorizeRequestFactoryApplePay(new TestConfig());
         $xmlNodeConverter = new XmlNodeConverter(
             new Writer()
         );
@@ -400,7 +400,7 @@ class ApiContext implements Context
             $params = $this->defineShippingAddressParams($params);
         }
 
-        $authRequestFactory = new AuthorizeRequestFactoryGooglePay();
+        $authRequestFactory = new AuthorizeRequestFactoryGooglePay(new TestConfig());
         $xmlNodeConverter = new XmlNodeConverter(
             new Writer()
         );

--- a/features/bootstrap/Services/TestConfig.php
+++ b/features/bootstrap/Services/TestConfig.php
@@ -25,4 +25,9 @@ class TestConfig implements Config
     {
         return "https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp";
     }
+
+    public function sendEmptyFraudsightFields(): bool
+    {
+        return true;
+    }
 }

--- a/spec/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactorySpec.php
+++ b/spec/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactorySpec.php
@@ -2,13 +2,16 @@
 
 namespace spec\Inviqa\Worldpay\Api\Request;
 
+use Inviqa\Worldpay\Config;
 use PhpSpec\ObjectBehavior;
 use Services\OrderFactory;
 
 class AuthorizeRequestFactorySpec extends ObjectBehavior
 {
-    function it_converts_a_list_of_parameters_into_a_payment_service_instance()
+    function it_converts_a_list_of_parameters_into_a_payment_service_instance(Config $config)
     {
+        $this->beConstructedWith($config);
+
         $this->buildFromRequestParameters(
             OrderFactory::simpleCseRequestParameters()
         )->shouldBeLike(OrderFactory::simpleCsePaymentService());

--- a/src/Inviqa/Worldpay/Api/Request/AuthoriseRequestTreeBuilder.php
+++ b/src/Inviqa/Worldpay/Api/Request/AuthoriseRequestTreeBuilder.php
@@ -56,18 +56,24 @@ use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\Shoppe
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\Shopper\Browser\UserAgentHeader;
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\Shopper\ShopperEmailAddress;
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Order;
-use Inviqa\Worldpay\Api\XmlNodeDefaults;
+use Inviqa\Worldpay\Config;
 
 class AuthoriseRequestTreeBuilder
 {
+    /**
+     * @var Config
+     */
+    private $config;
+
     /**
      * @var array
      */
     private $parameters;
 
-    public function __construct(array $parameters)
+    public function __construct(array $parameters, Config $config)
     {
         $this->parameters = $parameters;
+        $this->config = $config;
     }
 
     /**
@@ -262,6 +268,7 @@ class AuthoriseRequestTreeBuilder
     public function buildCustomStringFields()
     {
         return new CustomStringFields(
+            $this->config->sendEmptyFraudsightFields(),
             new CustomField('customStringField1', new CustomValue($this->parameters['shippingMethod'])),
             new CustomField('customStringField2', new CustomValue($this->parameters['productRisk'] ? 'High' : 'normal')),
             new CustomField('customStringField3', new CustomValue('')),
@@ -283,6 +290,7 @@ class AuthoriseRequestTreeBuilder
     public function buildCustomNumericFields()
     {
         return new CustomNumericFields(
+            $this->config->sendEmptyFraudsightFields(),
             new CustomField('customNumericField1', new CustomValue($this->parameters['ageOfAccount'])),
             new CustomField('customNumericField2', new CustomValue($this->parameters['timeSinceLastOrder'])),
             new CustomField('customNumericField3', new CustomValue($this->parameters['numberPurchases'])),

--- a/src/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactory.php
+++ b/src/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactory.php
@@ -13,9 +13,20 @@ use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\Paymen
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\PaymentDetails\Session;
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\PaymentDetailsWorldpay;
 use Inviqa\Worldpay\Api\Request\PaymentService\Version;
+use Inviqa\Worldpay\Config;
 
 class AuthorizeRequestFactory implements RequestFactory
 {
+    /**
+     * @var Config
+     */
+    private $config;
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
     const DEFAULT_PARAMETERS = [
         'version' => "1.4",
         'orderCode' => "",
@@ -77,7 +88,7 @@ class AuthorizeRequestFactory implements RequestFactory
             $parameters['shippingAddress'] += self::DEFAULT_ADDRESS_PARAMETERS;
         }
         $parameters += self::DEFAULT_PARAMETERS;
-        $treeBuilder = new AuthoriseRequestTreeBuilder($parameters);
+        $treeBuilder = new AuthoriseRequestTreeBuilder($parameters, $this->config);
 
         $orderCode = new OrderCode($parameters['orderCode']);
         $description = new Description($parameters['description']);

--- a/src/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactoryApplePay.php
+++ b/src/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactoryApplePay.php
@@ -19,9 +19,15 @@ use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\Paymen
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\PaymentDetails\ApplePaySSL\Version as ApplePayVersion;
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\PaymentDetailsApplePay;
 use Inviqa\Worldpay\Api\Request\PaymentService\Version;
+use Inviqa\Worldpay\Config;
 
 class AuthorizeRequestFactoryApplePay implements RequestFactory
 {
+    /**
+     * @var Config
+     */
+    private $config;
+
     private $defaultApplePayParameters = [
         'signature' => "dummy signature",
         'applePayVersion' => "dummy version",
@@ -29,6 +35,11 @@ class AuthorizeRequestFactoryApplePay implements RequestFactory
         'publicKeyHash' => "dummy hash",
         'transactionId' => "123456",
     ];
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
 
     /**
      * @param array $parameters
@@ -44,7 +55,7 @@ class AuthorizeRequestFactoryApplePay implements RequestFactory
         $parameters += AuthorizeRequestFactory::DEFAULT_PARAMETERS;
         $parameters += $this->defaultApplePayParameters;
 
-        $treeBuilder = new AuthoriseRequestTreeBuilder($parameters);
+        $treeBuilder = new AuthoriseRequestTreeBuilder($parameters, $this->config);
 
         $orderCode = new OrderCode($parameters['orderCode']);
         $description = new Description($parameters['description']);

--- a/src/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactoryGooglePay.php
+++ b/src/Inviqa/Worldpay/Api/Request/AuthorizeRequestFactoryGooglePay.php
@@ -22,13 +22,24 @@ use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\Paymen
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\PaymentDetails\Session;
 use Inviqa\Worldpay\Api\Request\PaymentService\Submit\Authorisation\Order\PaymentDetailsGooglePay;
 use Inviqa\Worldpay\Api\Request\PaymentService\Version;
+use Inviqa\Worldpay\Config;
 
 class AuthorizeRequestFactoryGooglePay implements RequestFactory
 {
+    /**
+     * @var Config
+     */
+    private $config;
+
     private $defaultGooglePayParameters = [
         'protocolVersion' => "dummy protocol version",
         'signature' => "dummy signature",
     ];
+
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
 
     /**
      * @param array $parameters
@@ -43,7 +54,7 @@ class AuthorizeRequestFactoryGooglePay implements RequestFactory
         }
         $parameters += AuthorizeRequestFactory::DEFAULT_PARAMETERS;
         $parameters += $this->defaultGooglePayParameters;
-        $treeBuilder = new AuthoriseRequestTreeBuilder($parameters);
+        $treeBuilder = new AuthoriseRequestTreeBuilder($parameters, $this->config);
 
         $orderCode = new OrderCode($parameters['orderCode']);
         $description = new Description($parameters['description']);

--- a/src/Inviqa/Worldpay/Api/Request/PaymentService/Submit/Authorisation/Order/FraudSightData/CustomNumericFields.php
+++ b/src/Inviqa/Worldpay/Api/Request/PaymentService/Submit/Authorisation/Order/FraudSightData/CustomNumericFields.php
@@ -7,6 +7,10 @@ use Inviqa\Worldpay\Api\XmlNodeDefaults;
 
 class CustomNumericFields extends XmlNodeDefaults
 {
+    /**
+     * @var bool
+     */
+    private $renderEmptyFields;
     private $customNumericField1;
     private $customNumericField2;
     private $customNumericField3;
@@ -19,6 +23,7 @@ class CustomNumericFields extends XmlNodeDefaults
     private $customNumericField10;
 
     public function __construct(
+        $renderEmptyFields,
         CustomField $customNumericField1,
         CustomField $customNumericField2,
         CustomField $customNumericField3,
@@ -30,6 +35,7 @@ class CustomNumericFields extends XmlNodeDefaults
         CustomField $customNumericField9,
         CustomField $customNumericField10
     ) {
+        $this->renderEmptyFields = $renderEmptyFields;
         $this->customNumericField1 = $customNumericField1;
         $this->customNumericField2 = $customNumericField2;
         $this->customNumericField3 = $customNumericField3;
@@ -44,7 +50,7 @@ class CustomNumericFields extends XmlNodeDefaults
 
     public function xmlChildren()
     {
-        return [
+        return array_filter([
             $this->customNumericField1,
             $this->customNumericField2,
             $this->customNumericField3,
@@ -55,6 +61,8 @@ class CustomNumericFields extends XmlNodeDefaults
             $this->customNumericField8,
             $this->customNumericField9,
             $this->customNumericField10
-        ];
+        ], function(CustomField $field) {
+            return $this->renderEmptyFields || !empty($field->string);
+        });
     }
 }

--- a/src/Inviqa/Worldpay/Api/Request/PaymentService/Submit/Authorisation/Order/FraudSightData/CustomStringFields.php
+++ b/src/Inviqa/Worldpay/Api/Request/PaymentService/Submit/Authorisation/Order/FraudSightData/CustomStringFields.php
@@ -7,6 +7,10 @@ use Inviqa\Worldpay\Api\XmlNodeDefaults;
 
 class CustomStringFields extends XmlNodeDefaults
 {
+    /**
+     * @var bool
+     */
+    private $renderEmptyFields;
     private $customStringField1;
     private $customStringField2;
     private $customStringField3;
@@ -19,6 +23,7 @@ class CustomStringFields extends XmlNodeDefaults
     private $customStringField10;
 
     public function __construct(
+        $renderEmptyFields,
         CustomField $customStringField1,
         CustomField $customStringField2,
         CustomField $customStringField3,
@@ -30,6 +35,7 @@ class CustomStringFields extends XmlNodeDefaults
         CustomField $customStringField9,
         CustomField $customStringField10
     ) {
+        $this->renderEmptyFields = $renderEmptyFields;
         $this->customStringField1 = $customStringField1;
         $this->customStringField2 = $customStringField2;
         $this->customStringField3 = $customStringField3;
@@ -44,7 +50,7 @@ class CustomStringFields extends XmlNodeDefaults
 
     public function xmlChildren()
     {
-        return [
+        return array_filter([
             $this->customStringField1,
             $this->customStringField2,
             $this->customStringField3,
@@ -55,6 +61,8 @@ class CustomStringFields extends XmlNodeDefaults
             $this->customStringField8,
             $this->customStringField9,
             $this->customStringField10
-        ];
+        ], function(CustomField $field) {
+            return $this->renderEmptyFields || !empty($field->string);
+        });
     }
 }

--- a/src/Inviqa/Worldpay/Application.php
+++ b/src/Inviqa/Worldpay/Application.php
@@ -39,7 +39,7 @@ class Application
         $this->client = $clientFactory->getClient();
 
         $this->paymentAuthorizer = PaymentAuthorizer::worldpayAuthorizer(
-            new AuthorizeRequestFactory(),
+            new AuthorizeRequestFactory($config),
             new ThreeDSRequestFactory(),
             new ThreeDSFlexRequestFactory(),
             new XmlNodeConverter(
@@ -49,7 +49,7 @@ class Application
         );
 
         $this->paymentAuthorizerApplePay = PaymentAuthorizer::applePayAuthorizer(
-            new AuthorizeRequestFactoryApplePay(),
+            new AuthorizeRequestFactoryApplePay($config),
             new XmlNodeConverter(
                 new Writer()
             ),
@@ -57,7 +57,7 @@ class Application
         );
 
         $this->paymentAuthorizerGooglePay = PaymentAuthorizer::googlePayAuthorizer(
-            new AuthorizeRequestFactoryGooglePay(),
+            new AuthorizeRequestFactoryGooglePay($config),
             new XmlNodeConverter(
                 new Writer()
             ),

--- a/src/Inviqa/Worldpay/Config.php
+++ b/src/Inviqa/Worldpay/Config.php
@@ -8,4 +8,5 @@ interface Config
     public function username(): string;
     public function password(): string;
     public function uri(): string;
+    public function sendEmptyFraudsightFields(): bool;
 }


### PR DESCRIPTION
Extend WorldpayConfiguration with the sendEmptyFraudsightFields
boolean option. By default it's set to true, meaning empty Fraudsight custom fields
will be included in the API request. When the option is set to false,
only fields containing non empty value will be included in the API
request.